### PR TITLE
Validate log level using tracing EnvFilter

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -34,9 +35,8 @@ impl Config {
             return Err(format!("Invalid server address: {}", self.server_addr));
         }
 
-        match self.log_level.to_lowercase().as_str() {
-            "trace" | "debug" | "info" | "warn" | "error" => {}
-            _ => return Err(format!("Invalid log level: {}", self.log_level)),
+        if EnvFilter::try_new(&self.log_level).is_err() {
+            return Err(format!("Invalid log level: {}", self.log_level));
         }
 
         if self.latest_articles_count == 0 {


### PR DESCRIPTION
## Summary
- import `EnvFilter` for log level validation
- validate `log_level` with `EnvFilter::try_new`

## Testing
- `cargo check &> /tmp/check.log && tail -n 20 /tmp/check.log`


------
https://chatgpt.com/codex/tasks/task_e_68bc2a7a67ec832a9fdcb601a706ac98