### PR TITLE
feat: add response cache with moka2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +415,27 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -537,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 2.0.16",
  "yaml-rust2",
 ]
 
@@ -919,6 +960,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc3c7fe956c9cabb0ae780604a882ba12aa9861070ec76ffbc39504862053be"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "triomphe",
+ "uuid",
+]
+
+[[package]]
 name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1078,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1168,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1147,6 +1238,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1230,6 +1330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,20 +1383,29 @@ name = "scribe"
 version = "0.3.0"
 dependencies = [
  "axum",
+ "bytes",
  "chrono",
  "gray_matter",
+ "moka2",
  "notify",
  "serde",
  "serde_json",
  "serde_yaml",
  "tantivy",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "toml",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "walkdir",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1450,6 +1568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tantivy"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,7 +1619,7 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.16",
  "time",
  "uuid",
  "winapi",
@@ -1610,11 +1734,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1828,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +2094,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ serde_yaml = "0.9.33"
 toml = "0.9.5"
 gray_matter = "0.3.2"
 
+# 缓存
+moka2 = { version = "0.13.0", features = ["future"] }
+bytes = "1.6"
+tower = "0.5"
+
 # 错误处理
 thiserror = "2.0.16"
 

--- a/config.toml
+++ b/config.toml
@@ -3,3 +3,5 @@ log_level = "scribe=debug,tower_http=debug"
 server_addr = "127.0.0.1:3000"
 latest_articles_count = 10
 enable_nested_categories = true
+cache_max_capacity = 1000
+cache_ttl_seconds = 60

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,1 +1,2 @@
 pub mod app;
+pub mod cache;

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -1,10 +1,13 @@
 use crate::config::Config;
+use crate::server::cache::ResponseCacheLayer;
 use crate::services::search::SearchService;
 use crate::services::service::ArticleStore;
 use axum::Router;
+use moka2::future::Cache;
 use notify::{RecursiveMode, Watcher};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -12,15 +15,29 @@ pub struct AppState {
     pub store: Arc<RwLock<ArticleStore>>,
     pub config: Arc<Config>,
     pub search_service: Option<Arc<SearchService>>,
+    pub cache: Arc<Cache<String, String>>,
 }
 
-pub async fn create_app_state(config: &Arc<Config>) -> Result<Arc<AppState>, Box<dyn std::error::Error>> {
+pub async fn create_app_state(
+    config: &Arc<Config>,
+) -> Result<Arc<AppState>, Box<dyn std::error::Error>> {
     let article_store = ArticleStore::new(&config.article_dir, config.enable_nested_categories)?;
+    let cache = Cache::builder()
+        .max_capacity(config.cache_max_capacity)
+        .time_to_live(Duration::from_secs(config.cache_ttl_seconds))
+        .build();
 
     let search_service = if config.enable_full_text_search {
         match SearchService::new(&config.search_index_dir) {
             Ok(service) => {
-                if let Err(e) = service.index_articles(&article_store.query(|_| true).into_iter().cloned().collect::<Vec<_>>(), config.search_index_heap_size) {
+                if let Err(e) = service.index_articles(
+                    &article_store
+                        .query(|_| true)
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    config.search_index_heap_size,
+                ) {
                     tracing::warn!("Failed to index articles: {:?}", e);
                     None
                 } else {
@@ -41,6 +58,7 @@ pub async fn create_app_state(config: &Arc<Config>) -> Result<Arc<AppState>, Box
         store: Arc::new(RwLock::new(article_store)),
         config: Arc::clone(config),
         search_service,
+        cache: Arc::new(cache),
     }))
 }
 
@@ -54,6 +72,7 @@ pub async fn start_server(app_state: Arc<AppState>, config: &Config) {
         .merge(crate::handlers::tags::create_router())
         .merge(crate::handlers::categories::create_router())
         .merge(crate::handlers::search::create_router())
+        .layer(ResponseCacheLayer::new(app_state.cache.clone()))
         .with_state(app_state);
 
     let addr: SocketAddr = config.server_addr.parse().expect("Invalid server address");
@@ -67,16 +86,15 @@ async fn watch_articles(state: Arc<AppState>) {
 
     let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
         if let Ok(event) = res
-            && (event.kind.is_modify() || event.kind.is_create() || event.kind.is_remove()) {
+            && (event.kind.is_modify() || event.kind.is_create() || event.kind.is_remove())
+        {
             tx.blocking_send(()).unwrap();
         }
     })
-        .unwrap();
+    .unwrap();
 
-    watcher.watch(
-        state.config.article_dir.as_ref(),
-        RecursiveMode::Recursive,
-    )
+    watcher
+        .watch(state.config.article_dir.as_ref(), RecursiveMode::Recursive)
         .unwrap();
 
     info!("Hot reloading enable for '{}'", state.config.article_dir);
@@ -87,9 +105,13 @@ async fn watch_articles(state: Arc<AppState>) {
         info!("File change detected, performing incremental update...");
         let mut store_guard = state.store.write().unwrap();
 
-        match store_guard.incremental_update(&state.config.article_dir, state.config.enable_nested_categories) {
+        match store_guard.incremental_update(
+            &state.config.article_dir,
+            state.config.enable_nested_categories,
+        ) {
             Ok(true) => {
                 reindex_articles_with_logging(&state, &store_guard);
+                state.cache.invalidate_all();
                 info!("Articles updated incrementally!");
             }
             Ok(false) => {
@@ -98,11 +120,15 @@ async fn watch_articles(state: Arc<AppState>) {
             Err(e) => {
                 tracing::error!("Error during incremental update: {:?}", e);
                 info!("Falling back to full reload...");
-                match ArticleStore::new(&state.config.article_dir, state.config.enable_nested_categories) {
+                match ArticleStore::new(
+                    &state.config.article_dir,
+                    state.config.enable_nested_categories,
+                ) {
                     Ok(new_store) => {
                         *store_guard = new_store;
 
                         reindex_articles_with_logging(&state, &store_guard);
+                        state.cache.invalidate_all();
 
                         info!("Full reload completed successfully!");
                     }
@@ -118,7 +144,9 @@ async fn watch_articles(state: Arc<AppState>) {
 fn reindex_articles_with_logging(state: &Arc<AppState>, store: &ArticleStore) {
     if let Some(ref search_service) = state.search_service {
         let articles: Vec<_> = store.query(|_| true).into_iter().cloned().collect();
-        if let Err(e) = search_service.index_articles(&articles, state.config.search_index_heap_size) {
+        if let Err(e) =
+            search_service.index_articles(&articles, state.config.search_index_heap_size)
+        {
             tracing::warn!("Failed to reindex articles for search: {:?}", e);
         } else {
             info!("Search index updated successfully!");

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -1,0 +1,91 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, Response};
+use moka2::future::Cache;
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct ResponseCacheLayer {
+    cache: Arc<Cache<String, String>>,
+}
+
+impl ResponseCacheLayer {
+    pub fn new(cache: Arc<Cache<String, String>>) -> Self {
+        Self { cache }
+    }
+}
+
+impl<S> Layer<S> for ResponseCacheLayer {
+    type Service = ResponseCacheService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ResponseCacheService {
+            inner,
+            cache: self.cache.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ResponseCacheService<S> {
+    inner: S,
+    cache: Arc<Cache<String, String>>,
+}
+
+impl<S> Service<Request<Body>> for ResponseCacheService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Error: Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        if req.method() != Method::GET {
+            let fut = self.inner.call(req);
+            return Box::pin(async move { fut.await });
+        }
+
+        let cache_key = {
+            let path = req.uri().path();
+            let query = req.uri().query().unwrap_or("");
+            let mut pairs: Vec<&str> = query.split('&').filter(|s| !s.is_empty()).collect();
+            pairs.sort_unstable();
+            format!("{}?{}", path, pairs.join("&"))
+        };
+
+        let cache = self.cache.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            if let Some(cached) = cache.get(&cache_key).await {
+                let resp = Response::builder()
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(cached))
+                    .unwrap();
+                return Ok(resp);
+            }
+
+            let resp = inner.call(req).await?;
+            let (parts, body) = resp.into_parts();
+            let bytes = to_bytes(body, usize::MAX).await.unwrap();
+            let body_str = String::from_utf8(bytes.to_vec()).unwrap();
+
+            if parts.status.is_success() {
+                cache.insert(cache_key, body_str.clone()).await;
+            }
+
+            Ok(Response::from_parts(parts, Body::from(body_str)))
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- integrate moka2 cache with configurable capacity and TTL
- cache API responses keyed by path and sorted query params
- invalidate cache on article updates

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bc390fa7b8832aa242fc2ff254227f