### PR TITLE
feat: lazily load article content

### DIFF
--- a/src/models/article.rs
+++ b/src/models/article.rs
@@ -21,11 +21,17 @@ pub struct Metadata {
 pub struct Article {
     pub slug: String,
     pub metadata: Metadata,
-    pub content: String,
     #[serde(skip_serializing)]
     pub file_path: String,
     #[serde(skip_serializing)]
     pub last_modified: SystemTime,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct ArticleContent {
+    pub slug: String,
+    pub metadata: Metadata,
+    pub content: String,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -37,7 +43,7 @@ pub struct ArticleTeaser {
 #[derive(Serialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum ArticleRepresentation {
-    Full(Article),
+    Full(ArticleContent),
     Teaser(ArticleTeaser),
 }
 

--- a/src/services/search.rs
+++ b/src/services/search.rs
@@ -1,4 +1,4 @@
-use crate::models::article::Article;
+use crate::models::article::ArticleContent;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -102,7 +102,7 @@ impl SearchService {
         schema_builder.build()
     }
 
-    pub fn index_articles(&self, articles: &[Article], heap_size: usize) -> Result<(), SearchError> {
+    pub fn index_articles(&self, articles: &[ArticleContent], heap_size: usize) -> Result<(), SearchError> {
         let mut index_writer = self.index.writer(heap_size)?;
 
         index_writer.delete_all_documents()?;


### PR DESCRIPTION
## Summary
- introduce `ArticleContent` to separate heavy article body from metadata
- load article content from disk on demand and update handlers to use it
- adjust search indexing to hydrate articles only when necessary

## Testing
- `cargo check`
- `cargo test` *(fails: command produced no output and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bc43178438832ab1bc7419dbdc2643