### PR TITLE
Use tokio RwLock for async-friendly concurrency

### DIFF
--- a/src/handlers/categories.rs
+++ b/src/handlers/categories.rs
@@ -10,9 +10,10 @@ pub fn create_router() -> Router<Arc<AppState>> {
     Router::new().route("/api/categories", get(get_all_categories))
 }
 
-async fn get_all_categories(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
-    let store = state.store.read()
-        .map_err(|_| AppError::BadRequest("Failed to acquire store lock".to_string()))?;
+async fn get_all_categories(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
+    let store = state.store.read().await;
     let categories = store.get_all_categories();
     Ok(Json(categories))
 }

--- a/src/handlers/tags.rs
+++ b/src/handlers/tags.rs
@@ -11,8 +11,7 @@ pub fn create_router() -> Router<Arc<AppState>> {
 }
 
 async fn get_all_tags(State(state): State<Arc<AppState>>) -> Result<impl IntoResponse, AppError> {
-    let store = state.store.read()
-        .map_err(|_| AppError::BadRequest("Failed to acquire store lock".to_string()))?;
+    let store = state.store.read().await;
     let tags = store.get_all_tags();
     Ok(Json(tags))
 }


### PR DESCRIPTION
## Summary
- replace blocking `std::sync::RwLock` with `tokio::sync::RwLock`
- record search stats with non-blocking `try_write`/`try_read`
- await lock access in server and handlers to avoid blocking async tasks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bc456642cc832abcc45eef7a1d54ba