### PR TITLE
Add article versioning APIs and model support

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3,3 +3,4 @@ pub mod tags;
 pub mod categories;
 pub mod error;
 pub mod search;
+pub mod article_versions;

--- a/src/handlers/article_versions.rs
+++ b/src/handlers/article_versions.rs
@@ -1,0 +1,105 @@
+use crate::handlers::error::AppError;
+use crate::models::version::VersionRecord;
+use crate::server::app::AppState;
+use crate::services::article_service::save_version;
+use axum::extract::{Path, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use std::fs;
+use std::path::Path as StdPath;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+pub fn create_router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/articles/:id/versions", get(list_versions))
+        .route("/api/articles/:id/versions/:version", get(get_version))
+        .route(
+            "/api/articles/:id/versions/:version/restore",
+            post(restore_version),
+        )
+}
+
+async fn list_versions(
+    Path(id): Path<String>,
+) -> Result<Json<Vec<VersionRecord>>, AppError> {
+    let version_dir = format!("data/articles/{}/versions", id);
+    if !StdPath::new(&version_dir).exists() {
+        return Ok(Json(vec![]));
+    }
+    let mut records = Vec::new();
+    let entries = fs::read_dir(&version_dir)
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if let Some(num_str) = file_name.strip_suffix(".md") {
+            if let Ok(ver) = num_str.parse::<u32>() {
+                let path = entry.path();
+                let content = fs::read_to_string(&path).unwrap_or_default();
+                let metadata = entry.metadata().ok();
+                let modified = metadata
+                    .and_then(|m| m.modified().ok())
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                let timestamp: DateTime<Utc> = modified.into();
+                records.push(VersionRecord {
+                    article_id: id.clone(),
+                    version: ver,
+                    content,
+                    timestamp,
+                    editor: "system".to_string(),
+                });
+            }
+        }
+    }
+    records.sort_by_key(|r| r.version);
+    Ok(Json(records))
+}
+
+async fn get_version(
+    Path((id, version)): Path<(String, u32)>,
+) -> Result<Json<VersionRecord>, AppError> {
+    let path = format!("data/articles/{}/versions/{}.md", id, version);
+    let content = fs::read_to_string(&path)
+        .map_err(|_| AppError::NotFound("Version not found".to_string()))?;
+    let metadata = fs::metadata(&path)
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+    let modified = metadata
+        .modified()
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+    let timestamp: DateTime<Utc> = modified.into();
+    Ok(Json(VersionRecord {
+        article_id: id,
+        version,
+        content,
+        timestamp,
+        editor: "system".to_string(),
+    }))
+}
+
+async fn restore_version(
+    State(state): State<Arc<AppState>>,
+    Path((id, version)): Path<(String, u32)>,
+) -> Result<Json<VersionRecord>, AppError> {
+    let store = state.store.read().await;
+    let article = store
+        .get_by_slug(&id)
+        .ok_or_else(|| AppError::NotFound("Article not found".to_string()))?;
+    let version_path = format!("data/articles/{}/versions/{}.md", id, version);
+    let content = fs::read_to_string(&version_path)
+        .map_err(|_| AppError::NotFound("Version not found".to_string()))?;
+    fs::write(&article.file_path, &content)
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+    save_version(article)
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+    let timestamp = Utc::now();
+    Ok(Json(VersionRecord {
+        article_id: id,
+        version,
+        content,
+        timestamp,
+        editor: "system".to_string(),
+    }))
+}

--- a/src/handlers/error.rs
+++ b/src/handlers/error.rs
@@ -9,6 +9,7 @@ use std::io::Error as IoError;
 pub enum AppError {
     NotFound(String),
     BadRequest(String),
+    InternalServerError(String),
 }
 
 impl IntoResponse for AppError {
@@ -16,6 +17,7 @@ impl IntoResponse for AppError {
         let (status, error_message) = match self {
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            AppError::InternalServerError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
 
         let body = Json(json!({

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,1 +1,2 @@
 pub mod article;
+pub mod version;

--- a/src/models/article.rs
+++ b/src/models/article.rs
@@ -21,6 +21,8 @@ pub struct Metadata {
 pub struct Article {
     pub slug: String,
     pub metadata: Metadata,
+    pub version: u32,
+    pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing)]
     pub file_path: String,
     #[serde(skip_serializing)]

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -1,0 +1,11 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct VersionRecord {
+    pub article_id: String,
+    pub version: u32,
+    pub content: String,
+    pub timestamp: DateTime<Utc>,
+    pub editor: String,
+}

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -70,6 +70,7 @@ pub fn start_file_watcher(app_state: Arc<AppState>) {
 pub async fn start_server(app_state: Arc<AppState>, config: &Config) {
     let app = Router::new()
         .merge(crate::handlers::articles::create_router())
+        .merge(crate::handlers::article_versions::create_router())
         .merge(crate::handlers::tags::create_router())
         .merge(crate::handlers::categories::create_router())
         .merge(crate::handlers::search::create_router())

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,2 +1,3 @@
 pub mod service;
 pub mod search;
+pub mod article_service;

--- a/src/services/article_service.rs
+++ b/src/services/article_service.rs
@@ -1,0 +1,15 @@
+use crate::models::article::Article;
+use std::fs;
+use std::io::Result;
+use std::path::Path;
+
+pub fn save_version(article: &Article) -> Result<()> {
+    let version_dir = format!("data/articles/{}/versions", article.slug);
+    fs::create_dir_all(&version_dir)?;
+    let next_version = fs::read_dir(&version_dir)
+        .map(|rd| rd.count() as u32 + 1)
+        .unwrap_or(1);
+    let content = fs::read_to_string(&article.file_path)?;
+    let version_file = Path::new(&version_dir).join(format!("{}.md", next_version));
+    fs::write(version_file, content)
+}

--- a/src/services/service.rs
+++ b/src/services/service.rs
@@ -1,5 +1,6 @@
 use crate::handlers::error::LoadError;
 use crate::models::article::{Article, ArticleContent, Metadata};
+use chrono::{DateTime, Utc};
 use gray_matter::engine::YAML;
 use gray_matter::Matter;
 use serde_yaml::from_value;
@@ -355,10 +356,17 @@ impl ArticleStore {
         let last_modified = fs::metadata(path)
             .and_then(|m| m.modified())
             .unwrap_or(SystemTime::UNIX_EPOCH);
+        let updated_at: DateTime<Utc> = last_modified.into();
+        let version_dir = format!("data/articles/{}/versions", slug);
+        let version = fs::read_dir(&version_dir)
+            .map(|rd| rd.count() as u32 + 1)
+            .unwrap_or(1);
 
         articles.push(Article {
             slug,
             metadata,
+            version,
+            updated_at,
             file_path: path.to_string_lossy().to_string(),
             last_modified,
         });


### PR DESCRIPTION
## Summary
- track article versions and last update time
- persist article versions on disk and expose version management APIs
- add internal error variant for handler responses

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd41c7e71c832a833f4d344b6259a1