### PR TITLE
feat: add structured error handling and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Scribe
+
+This project exposes a REST API for managing articles. Errors are returned in a
+consistent JSON format and are logged for easier debugging.
+
+## Error Codes
+
+| Code | Description |
+| --- | --- |
+| `ERR_ARTICLE_NOT_FOUND` | Requested article does not exist |
+| `ERR_VERSION_NOT_FOUND` | Requested article version is missing |
+| `ERR_FULLTEXT_DISABLED` | Full‑text search service is not available |
+| `ERR_EMPTY_SEARCH_QUERY` | Search query parameter was empty |
+| `ERR_BAD_REQUEST` | Request parameters were invalid |
+| `ERR_INTERNAL_SERVER` | Unexpected internal error |
+| `ERR_INVALID_SESSION` | Example code for an unauthenticated session |
+
+Responses use the shape:
+
+```json
+{"error_code": "ERR_ARTICLE_NOT_FOUND", "message": "Article with slug foo not found"}
+```
+
+## Logging
+
+The application uses [`tracing`](https://crates.io/crates/tracing) for logging.
+Run the server with an appropriate `RUST_LOG` level to see messages:
+
+```bash
+RUST_LOG=error cargo run
+```
+
+Error logs can then be viewed in the console or collected by your preferred log
+aggregator.
+

--- a/src/handlers/articles.rs
+++ b/src/handlers/articles.rs
@@ -1,4 +1,4 @@
-use crate::handlers::error::AppError;
+use crate::handlers::error::{AppError, ERR_ARTICLE_NOT_FOUND, ERR_BAD_REQUEST};
 use crate::models::article::{
     ArticleContent, ArticleRepresentation, ArticleTeaser, PaginatedArticles,
 };
@@ -148,20 +148,23 @@ async fn get_article_by_slug(
         Some(article) if !article.metadata.draft => {
             let content = store
                 .load_content_for(article)
-                .map_err(|e| AppError::BadRequest(e.to_string()))?;
+                .map_err(|e| AppError::BadRequest {
+                    code: ERR_BAD_REQUEST,
+                    message: e.to_string(),
+                })?;
             Ok(Json(ArticleContent {
                 slug: article.slug.clone(),
                 metadata: article.metadata.clone(),
                 content,
             }))
         }
-        Some(_) => Err(AppError::NotFound(format!(
-            "Article with slug {} not found",
-            slug
-        ))),
-        None => Err(AppError::NotFound(format!(
-            "Article with slug {} not found",
-            slug
-        ))),
+        Some(_) => Err(AppError::NotFound {
+            code: ERR_ARTICLE_NOT_FOUND,
+            message: format!("Article with slug {} not found", slug),
+        }),
+        None => Err(AppError::NotFound {
+            code: ERR_ARTICLE_NOT_FOUND,
+            message: format!("Article with slug {} not found", slug),
+        }),
     }
 }

--- a/src/handlers/error.rs
+++ b/src/handlers/error.rs
@@ -1,28 +1,42 @@
+use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use serde_json::json;
 use serde_yaml::Error as SerdeYAMLError;
 use std::io::Error as IoError;
+use tracing::error;
+
+pub const ERR_INTERNAL_SERVER: &str = "ERR_INTERNAL_SERVER";
+pub const ERR_BAD_REQUEST: &str = "ERR_BAD_REQUEST";
+pub const ERR_ARTICLE_NOT_FOUND: &str = "ERR_ARTICLE_NOT_FOUND";
+pub const ERR_VERSION_NOT_FOUND: &str = "ERR_VERSION_NOT_FOUND";
+pub const ERR_FULLTEXT_DISABLED: &str = "ERR_FULLTEXT_DISABLED";
+pub const ERR_EMPTY_SEARCH_QUERY: &str = "ERR_EMPTY_SEARCH_QUERY";
+#[allow(dead_code)]
+pub const ERR_INVALID_SESSION: &str = "ERR_INVALID_SESSION";
 
 #[derive(Debug)]
 pub enum AppError {
-    NotFound(String),
-    BadRequest(String),
-    InternalServerError(String),
+    NotFound { code: &'static str, message: String },
+    BadRequest { code: &'static str, message: String },
+    InternalServerError { code: &'static str, message: String },
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, error_message) = match self {
-            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
-            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            AppError::InternalServerError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+        let (status, code, message) = match self {
+            AppError::NotFound { code, message } => (StatusCode::NOT_FOUND, code, message),
+            AppError::BadRequest { code, message } => (StatusCode::BAD_REQUEST, code, message),
+            AppError::InternalServerError { code, message } => {
+                (StatusCode::INTERNAL_SERVER_ERROR, code, message)
+            }
         };
 
+        error!(error_code = code, message = %message);
+
         let body = Json(json!({
-            "error": status.canonical_reason().unwrap_or("Unknown error"),
-            "message": error_message,
+            "error_code": code,
+            "message": message,
         }));
 
         (status, body).into_response()
@@ -45,7 +59,9 @@ impl std::fmt::Display for LoadError {
             LoadError::YamlParse(err) => write!(f, "YAML parsing error: {}", err),
             LoadError::MatterParse(msg) => write!(f, "Front matter parsing error: {}", msg),
             LoadError::InvalidFileName(filename) => write!(f, "Invalid file name: {}", filename),
-            LoadError::MissingFrontMatter(filename) => write!(f, "Missing front matter in file: {}", filename),
+            LoadError::MissingFrontMatter(filename) => {
+                write!(f, "Missing front matter in file: {}", filename)
+            }
         }
     }
 }

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -1,4 +1,4 @@
-use crate::handlers::error::AppError;
+use crate::handlers::error::{AppError, ERR_EMPTY_SEARCH_QUERY, ERR_FULLTEXT_DISABLED};
 use crate::server::app::AppState;
 use crate::services::search::SearchResult;
 use axum::extract::{Query, State};
@@ -46,15 +46,19 @@ async fn search_articles(
     let search_service = state
         .search_service
         .as_ref()
-        .ok_or_else(|| AppError::BadRequest("Full-text search is not enabled".to_string()))?;
+        .ok_or_else(|| AppError::BadRequest {
+            code: ERR_FULLTEXT_DISABLED,
+            message: "Full-text search is not enabled".to_string(),
+        })?;
 
     let limit = params.limit.unwrap_or(20);
     let highlights = params.highlights.unwrap_or(true);
 
     if params.q.trim().is_empty() {
-        return Err(AppError::BadRequest(
-            "Search query cannot be empty".to_string(),
-        ));
+        return Err(AppError::BadRequest {
+            code: ERR_EMPTY_SEARCH_QUERY,
+            message: "Search query cannot be empty".to_string(),
+        });
     }
 
     match search_service.search(&params.q, limit, highlights) {
@@ -119,7 +123,10 @@ async fn get_popular_searches(
     let search_service = state
         .search_service
         .as_ref()
-        .ok_or_else(|| AppError::BadRequest("Full-text search is not enabled".to_string()))?;
+        .ok_or_else(|| AppError::BadRequest {
+            code: ERR_FULLTEXT_DISABLED,
+            message: "Full-text search is not enabled".to_string(),
+        })?;
 
     let popular_searches = search_service.get_popular_searches(10);
     let searches: Vec<PopularSearch> = popular_searches


### PR DESCRIPTION
## Summary
- add error codes to `AppError` and return `{error_code, message}`
- log errors globally and via `AppError` responses
- document error codes and logging in README

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd64867c04832a90f81a6036266b95