### PR TITLE
feat: add admin token middleware

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,5 +3,6 @@ log_level = "scribe=debug,tower_http=debug"
 server_addr = "127.0.0.1:3000"
 latest_articles_count = 10
 enable_nested_categories = true
+admin_token = "change-me"
 cache_max_capacity = 1000
 cache_ttl_seconds = 60

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub latest_articles_count: usize,
     #[serde(default)]
     pub enable_nested_categories: bool,
+    pub admin_token: String,
     #[serde(default = "default_search_index_dir")]
     pub search_index_dir: String,
     #[serde(default)]
@@ -63,6 +64,10 @@ impl Config {
 
         if self.cache_ttl_seconds == 0 {
             return Err("Cache TTL must be greater than 0".to_string());
+        }
+
+        if self.admin_token.trim().is_empty() {
+            return Err("Admin token cannot be empty".to_string());
         }
 
         Ok(())

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,6 +1,6 @@
+pub mod article_versions;
 pub mod articles;
-pub mod tags;
 pub mod categories;
 pub mod error;
 pub mod search;
-pub mod article_versions;
+pub mod tags;

--- a/src/handlers/article_versions.rs
+++ b/src/handlers/article_versions.rs
@@ -3,8 +3,10 @@ use crate::handlers::error::{
 };
 use crate::models::version::VersionRecord;
 use crate::server::app::AppState;
+use crate::server::auth::require_admin;
 use crate::services::article_service::save_version;
 use axum::extract::{Path, State};
+use axum::middleware;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
@@ -19,7 +21,7 @@ pub fn create_router() -> Router<Arc<AppState>> {
         .route("/api/articles/{id}/versions/{version}", get(get_version))
         .route(
             "/api/articles/{id}/versions/{version}/restore",
-            post(restore_version),
+            post(restore_version).route_layer(middleware::from_fn(require_admin)),
         )
 }
 

--- a/src/handlers/error.rs
+++ b/src/handlers/error.rs
@@ -14,12 +14,14 @@ pub const ERR_FULLTEXT_DISABLED: &str = "ERR_FULLTEXT_DISABLED";
 pub const ERR_EMPTY_SEARCH_QUERY: &str = "ERR_EMPTY_SEARCH_QUERY";
 #[allow(dead_code)]
 pub const ERR_INVALID_SESSION: &str = "ERR_INVALID_SESSION";
+pub const ERR_UNAUTHORIZED: &str = "ERR_UNAUTHORIZED";
 
 #[derive(Debug)]
 pub enum AppError {
     NotFound { code: &'static str, message: String },
     BadRequest { code: &'static str, message: String },
     InternalServerError { code: &'static str, message: String },
+    Unauthorized { code: &'static str, message: String },
 }
 
 impl IntoResponse for AppError {
@@ -30,6 +32,7 @@ impl IntoResponse for AppError {
             AppError::InternalServerError { code, message } => {
                 (StatusCode::INTERNAL_SERVER_ERROR, code, message)
             }
+            AppError::Unauthorized { code, message } => (StatusCode::UNAUTHORIZED, code, message),
         };
 
         error!(error_code = code, message = %message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@ use crate::config::{initialize_config, initialize_logging};
 use crate::server::app::{create_app_state, start_file_watcher, start_server};
 use std::sync::Arc;
 
-mod models;
-mod handlers;
-mod services;
 mod config;
+mod handlers;
+mod models;
 mod server;
+mod services;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/models/article.rs
+++ b/src/models/article.rs
@@ -27,6 +27,8 @@ pub struct Article {
     pub file_path: String,
     #[serde(skip_serializing)]
     pub last_modified: SystemTime,
+    #[serde(skip_serializing, default)]
+    pub deleted: bool,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,2 +1,3 @@
 pub mod app;
+pub mod auth;
 pub mod cache;

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,0 +1,29 @@
+use crate::handlers::error::{AppError, ERR_UNAUTHORIZED};
+use crate::server::app::AppState;
+use axum::body::Body;
+use axum::http::{Request, header::AUTHORIZATION};
+use axum::middleware::Next;
+use axum::response::Response;
+use std::sync::Arc;
+
+pub async fn require_admin(req: Request<Body>, next: Next) -> Result<Response, AppError> {
+    let state = req
+        .extensions()
+        .get::<Arc<AppState>>()
+        .cloned()
+        .expect("AppState missing");
+
+    let auth_header = req
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|h| h.to_str().ok());
+
+    if auth_header != Some(state.config.admin_token.as_str()) {
+        return Err(AppError::Unauthorized {
+            code: ERR_UNAUTHORIZED,
+            message: "Invalid admin token".to_string(),
+        });
+    }
+
+    Ok(next.run(req).await)
+}

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,3 +1,3 @@
-pub mod service;
-pub mod search;
 pub mod article_service;
+pub mod search;
+pub mod service;


### PR DESCRIPTION
## Summary
- add admin_token configuration and validation
- create admin authentication middleware and apply to article version restore endpoint

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c04676dd00832ab65350125c6c614f