### PR TITLE
fix: inject app state into admin middleware

### DIFF
--- a/src/handlers/article_versions.rs
+++ b/src/handlers/article_versions.rs
@@ -15,13 +15,13 @@ use std::path::Path as StdPath;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-pub fn create_router() -> Router<Arc<AppState>> {
+pub fn create_router(state: Arc<AppState>) -> Router<Arc<AppState>> {
     Router::new()
         .route("/api/articles/{id}/versions", get(list_versions))
         .route("/api/articles/{id}/versions/{version}", get(get_version))
         .route(
             "/api/articles/{id}/versions/{version}/restore",
-            post(restore_version).route_layer(middleware::from_fn(require_admin)),
+            post(restore_version).route_layer(middleware::from_fn_with_state(state, require_admin)),
         )
 }
 

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -73,7 +73,9 @@ pub fn start_file_watcher(app_state: Arc<AppState>) {
 pub async fn start_server(app_state: Arc<AppState>, config: &Config) {
     let app = Router::new()
         .merge(crate::handlers::articles::create_router())
-        .merge(crate::handlers::article_versions::create_router())
+        .merge(crate::handlers::article_versions::create_router(
+            app_state.clone(),
+        ))
         .merge(crate::handlers::tags::create_router())
         .merge(crate::handlers::categories::create_router())
         .merge(crate::handlers::search::create_router())

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,18 +1,17 @@
 use crate::handlers::error::{AppError, ERR_UNAUTHORIZED};
 use crate::server::app::AppState;
 use axum::body::Body;
+use axum::extract::State;
 use axum::http::{Request, header::AUTHORIZATION};
 use axum::middleware::Next;
 use axum::response::Response;
 use std::sync::Arc;
 
-pub async fn require_admin(req: Request<Body>, next: Next) -> Result<Response, AppError> {
-    let state = req
-        .extensions()
-        .get::<Arc<AppState>>()
-        .cloned()
-        .expect("AppState missing");
-
+pub async fn require_admin(
+    State(state): State<Arc<AppState>>,
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, AppError> {
     let auth_header = req
         .headers()
         .get(AUTHORIZATION)


### PR DESCRIPTION
## Summary
- inject `AppState` via `State` extractor in admin middleware
- apply middleware with `from_fn_with_state` on version restore route

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c04d6fe230832a8a8abb5c24366941