### PR TITLE
Persist and validate GitHub OAuth state token

### DIFF
--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -1,6 +1,10 @@
-use crate::handlers::error::{AppError, ERR_INTERNAL_SERVER};
+use crate::handlers::error::{AppError, ERR_BAD_REQUEST, ERR_INTERNAL_SERVER};
 use crate::server::app::AppState;
 use axum::extract::{Query, State};
+use axum::http::{
+    HeaderMap, HeaderValue,
+    header::{COOKIE, SET_COOKIE},
+};
 use axum::response::Redirect;
 use axum::routing::get;
 use axum::{Json, Router};
@@ -23,27 +27,28 @@ pub fn create_router() -> Router<Arc<AppState>> {
 fn oauth_client(state: &AppState) -> BasicClient {
     BasicClient::new(
         ClientId::new(state.config.github_client_id.clone()),
-        Some(ClientSecret::new(
-            state.config.github_client_secret.clone(),
-        )),
+        Some(ClientSecret::new(state.config.github_client_secret.clone())),
         AuthUrl::new("https://github.com/login/oauth/authorize".to_string()).unwrap(),
-        Some(TokenUrl::new(
-            "https://github.com/login/oauth/access_token".to_string(),
-        )
-        .unwrap()),
+        Some(TokenUrl::new("https://github.com/login/oauth/access_token".to_string()).unwrap()),
     )
-    .set_redirect_uri(
-        RedirectUrl::new(state.config.github_redirect_url.clone()).unwrap(),
-    )
+    .set_redirect_uri(RedirectUrl::new(state.config.github_redirect_url.clone()).unwrap())
 }
 
-async fn github_login(State(state): State<Arc<AppState>>) -> Redirect {
+async fn github_login(State(state): State<Arc<AppState>>) -> impl axum::response::IntoResponse {
     let client = oauth_client(&state);
-    let (auth_url, _csrf_token) = client
+    let (auth_url, csrf_token) = client
         .authorize_url(CsrfToken::new_random)
         .add_scope(Scope::new("read:user".to_string()))
         .url();
-    Redirect::to(auth_url.as_str())
+
+    let mut headers = HeaderMap::new();
+    let cookie = format!(
+        "github_oauth_state={}; HttpOnly; SameSite=Lax",
+        csrf_token.secret()
+    );
+    headers.insert(SET_COOKIE, HeaderValue::from_str(&cookie).unwrap());
+
+    (headers, Redirect::to(auth_url.as_str()))
 }
 
 #[derive(Deserialize)]
@@ -60,8 +65,31 @@ struct GitHubUser {
 
 async fn github_callback(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<AuthRequest>,
 ) -> Result<Json<GitHubUser>, AppError> {
+    let state_cookie = headers
+        .get(COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|cookie_header| {
+            cookie_header.split(';').find_map(|cookie| {
+                let cookie = cookie.trim();
+                cookie
+                    .strip_prefix("github_oauth_state=")
+                    .map(|v| v.to_string())
+            })
+        })
+        .ok_or_else(|| AppError::BadRequest {
+            code: ERR_BAD_REQUEST,
+            message: "missing OAuth state".to_string(),
+        })?;
+    if state_cookie != query.state {
+        return Err(AppError::BadRequest {
+            code: ERR_BAD_REQUEST,
+            message: "invalid OAuth state".to_string(),
+        });
+    }
+
     let client = oauth_client(&state);
     let token = client
         .exchange_code(AuthorizationCode::new(query.code))


### PR DESCRIPTION
## Summary
- store generated OAuth state token in a cookie during login
- validate callback requests against the stored token

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c054f6a220832a8ec0a1aeac7ff8ca