### PR TITLE
Mark OAuth state cookie secure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +328,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -2000,6 +2034,7 @@ name = "scribe"
 version = "0.3.0"
 dependencies = [
  "axum",
+ "axum-extra",
  "bytes",
  "chrono",
  "gray_matter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ tantivy = "0.25.0"
 # OAuth2 支持
 oauth2 = { version = "4", default-features = false, features = ["reqwest", "rustls-tls"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+axum-extra = { version = "0.10", features = ["cookie"] }


### PR DESCRIPTION
## Summary
- add cookie support with `axum-extra`
- mark OAuth state cookie as `Secure`
- validate OAuth state from stored cookie

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c05a2bd568832aacee8c174fe08086