### PR TITLE
Secure admin token via hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2044,7 @@ dependencies = [
  "bytes",
  "chrono",
  "gray_matter",
+ "hex",
  "moka2",
  "notify",
  "oauth2",
@@ -2045,6 +2052,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
+ "subtle",
  "tantivy",
  "thiserror 2.0.16",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ tower = "0.5"
 # 错误处理
 thiserror = "2.0.16"
 
+# cryptography
+sha2 = "0.10"
+subtle = "2.5"
+hex = "0.4"
+
 # 时间库
 chrono = { version = "0.4.41", features = ["serde"] }
 

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,6 @@ log_level = "scribe=debug,tower_http=debug"
 server_addr = "127.0.0.1:3000"
 latest_articles_count = 10
 enable_nested_categories = true
-admin_token = "change-me"
 cache_max_capacity = 1000
 cache_ttl_seconds = 60
 github_client_id = "your-client-id"

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,29 +1,29 @@
+use crate::config::get_admin_token_hash;
 use crate::handlers::error::{AppError, ERR_UNAUTHORIZED};
-use crate::server::app::AppState;
 use axum::body::Body;
 use axum::http::{Request, header::AUTHORIZATION};
 use axum::middleware::Next;
 use axum::response::Response;
-use std::sync::Arc;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 
 pub async fn require_admin(req: Request<Body>, next: Next) -> Result<Response, AppError> {
-    let state = req
-        .extensions()
-        .get::<Arc<AppState>>()
-        .cloned()
-        .expect("AppState missing");
-
     let auth_header = req
         .headers()
         .get(AUTHORIZATION)
         .and_then(|h| h.to_str().ok());
 
-    if auth_header != Some(state.config.admin_token.as_str()) {
-        return Err(AppError::Unauthorized {
-            code: ERR_UNAUTHORIZED,
-            message: "Invalid admin token".to_string(),
-        });
+    let stored_hash = get_admin_token_hash().expect("ADMIN_TOKEN_HASH must be set");
+
+    if let Some(token) = auth_header {
+        let provided_hash: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+        if provided_hash.ct_eq(&stored_hash).unwrap_u8() == 1 {
+            return Ok(next.run(req).await);
+        }
     }
 
-    Ok(next.run(req).await)
+    Err(AppError::Unauthorized {
+        code: ERR_UNAUTHORIZED,
+        message: "Invalid admin token".to_string(),
+    })
 }


### PR DESCRIPTION
## Summary
- Authenticate admin requests by hashing tokens and comparing using a constant-time check
- Load `ADMIN_TOKEN_HASH` from environment and remove `admin_token` from config
- Add crypto dependencies for SHA-256 hashing and constant-time comparison

## Testing
- `ADMIN_TOKEN_HASH=0000000000000000000000000000000000000000000000000000000000000000 cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c060dec924832a9e3b8b79a95947f0