### PR TITLE
docs: add Chinese README translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 This project exposes a REST API for managing articles. Errors are returned in a
 consistent JSON format and are logged for easier debugging.
 
+## Configuration
+
+Runtime configuration is read from `config.toml`. Important options include:
+
+```toml
+article_dir = "article"
+log_level = "scribe=debug,tower_http=debug"
+server_addr = "127.0.0.1:3000"
+latest_articles_count = 10
+enable_nested_categories = true
+cache_max_capacity = 1000
+cache_ttl_seconds = 60
+github_redirect_url = "http://localhost:3000/api/auth/github/callback"
+```
+
+The server watches `article_dir` for changes and automatically reloads
+modified files. Optional full‑text search can be enabled with
+`enable_full_text_search`.
+
 ## Error Codes
 
 | Code | Description |
@@ -40,4 +59,23 @@ The application reads the following values from the environment (or a `.env` fil
 - `ADMIN_TOKEN_HASH` – SHA-256 hash of the admin token used for admin‑only routes.
 - `GITHUB_CLIENT_ID` – OAuth client identifier for GitHub authentication.
 - `GITHUB_CLIENT_SECRET` – OAuth client secret for GitHub authentication.
+- `COOKIE_SECRET` – secret key used to sign session cookies.
+ 
+## API Endpoints
+
+The server exposes the following HTTP endpoints:
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/api/articles` | List articles with optional `tag`, `category`, `q`, `include_content`, `page`, and `limit` query parameters |
+| GET | `/api/articles/{slug}` | Retrieve a single article by slug |
+| GET | `/api/articles/{id}/versions` | List saved versions for an article |
+| GET | `/api/articles/{id}/versions/{version}` | Fetch a specific version of an article |
+| POST | `/api/articles/{id}/versions/{version}/restore` | Restore an article to a previous version *(admin only)* |
+| GET | `/api/tags` | Retrieve all tags |
+| GET | `/api/categories` | Retrieve all categories |
+| GET | `/api/search` | Search articles (requires full‑text search to be enabled) |
+| GET | `/api/search/popular` | List popular search queries |
+| GET | `/api/auth/github/login` | Start GitHub OAuth login flow |
+| GET | `/api/auth/github/callback` | OAuth callback endpoint used after GitHub login |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,75 @@
+# Scribe
+
+该项目提供用于管理文章的 REST API。错误以一致的 JSON 格式返回，并会记录日志以便调试。
+
+## 配置
+
+运行时配置从 `config.toml` 读取。重要选项包括：
+
+```toml
+article_dir = "article"
+log_level = "scribe=debug,tower_http=debug"
+server_addr = "127.0.0.1:3000"
+latest_articles_count = 10
+enable_nested_categories = true
+cache_max_capacity = 1000
+cache_ttl_seconds = 60
+github_redirect_url = "http://localhost:3000/api/auth/github/callback"
+```
+
+服务器会监视 `article_dir` 的变化并自动重新加载被修改的文件。可选的全文搜索可以通过 `enable_full_text_search` 启用。
+
+## 错误码
+
+| 代码 | 描述 |
+| --- | --- |
+| `ERR_ARTICLE_NOT_FOUND` | 请求的文章不存在 |
+| `ERR_VERSION_NOT_FOUND` | 请求的文章版本缺失 |
+| `ERR_FULLTEXT_DISABLED` | 全文搜索服务不可用 |
+| `ERR_EMPTY_SEARCH_QUERY` | 搜索查询参数为空 |
+| `ERR_BAD_REQUEST` | 请求参数无效 |
+| `ERR_INTERNAL_SERVER` | 未预期的内部错误 |
+| `ERR_INVALID_SESSION` | 未认证会话示例 |
+
+响应使用如下格式：
+
+```json
+{"error_code": "ERR_ARTICLE_NOT_FOUND", "message": "Article with slug foo not found"}
+```
+
+## 日志
+
+应用使用 [`tracing`](https://crates.io/crates/tracing) 进行日志记录。运行服务器时配置合适的 `RUST_LOG` 级别以查看消息：
+
+```bash
+RUST_LOG=error cargo run
+```
+
+然后可以在控制台查看错误日志或将其收集到你的日志聚合器中。
+
+## 环境变量
+
+应用从环境（或 `.env` 文件）读取以下值：
+
+- `ADMIN_TOKEN_HASH` – 管理员路由所用 token 的 SHA-256 哈希。
+- `GITHUB_CLIENT_ID` – GitHub 认证用的 OAuth client ID。
+- `GITHUB_CLIENT_SECRET` – GitHub 认证用的 OAuth client secret。
+- `COOKIE_SECRET` – 用于签名会话 cookie 的密钥。
+
+## API 端点
+
+服务器暴露以下 HTTP 端点：
+
+| 方法 | 路径 | 描述 |
+| ---- | ---- | ---- |
+| GET | `/api/articles` | 列出文章，可选查询参数：`tag`、`category`、`q`、`include_content`、`page`、`limit` |
+| GET | `/api/articles/{slug}` | 通过 slug 获取文章 |
+| GET | `/api/articles/{id}/versions` | 列出文章保存的版本 |
+| GET | `/api/articles/{id}/versions/{version}` | 获取文章的指定版本 |
+| POST | `/api/articles/{id}/versions/{version}/restore` | 将文章恢复到指定版本（仅管理员） |
+| GET | `/api/tags` | 获取所有标签 |
+| GET | `/api/categories` | 获取所有分类 |
+| GET | `/api/search` | 搜索文章（需要启用全文搜索） |
+| GET | `/api/search/popular` | 列出热门搜索 |
+| GET | `/api/auth/github/login` | 启动 GitHub OAuth 登录流程 |
+| GET | `/api/auth/github/callback` | GitHub 登录完成后的回调端点 |


### PR DESCRIPTION
## Summary
- document config options and hot reloading
- note cookie secret in environment variables
- list available API endpoints
- add Chinese README translation

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c0699fc7c0832a97835d492f0ad7e4