### PR TITLE
feat: make comments optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ log_level = "scribe=debug,tower_http=debug"
 server_addr = "127.0.0.1:3000"
 latest_articles_count = 10
 enable_nested_categories = true
+enable_comments = false
 cache_max_capacity = 1000
 cache_ttl_seconds = 60
 github_redirect_url = "http://localhost:3000/api/auth/github/callback"
@@ -20,7 +21,8 @@ github_redirect_url = "http://localhost:3000/api/auth/github/callback"
 
 The server watches `article_dir` for changes and automatically reloads
 modified files. Optional full‑text search can be enabled with
-`enable_full_text_search`.
+`enable_full_text_search`. Comment endpoints and widgets remain disabled
+unless `enable_comments` is set to `true`.
 
 ## Error Codes
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -12,12 +12,13 @@ log_level = "scribe=debug,tower_http=debug"
 server_addr = "127.0.0.1:3000"
 latest_articles_count = 10
 enable_nested_categories = true
+enable_comments = false
 cache_max_capacity = 1000
 cache_ttl_seconds = 60
 github_redirect_url = "http://localhost:3000/api/auth/github/callback"
 ```
 
-服务器会监视 `article_dir` 的变化并自动重新加载被修改的文件。可选的全文搜索可以通过 `enable_full_text_search` 启用。
+服务器会监视 `article_dir` 的变化并自动重新加载被修改的文件。可选的全文搜索可以通过 `enable_full_text_search` 启用。评论端点和小部件默认关闭，除非将 `enable_comments` 设置为 `true`。
 
 ## 错误码
 

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ server_addr = "127.0.0.1:3000"
 base_url = "http://localhost:3000"
 latest_articles_count = 10
 enable_nested_categories = true
+enable_comments = false
 cache_max_capacity = 1000
 cache_ttl_seconds = 60
 github_redirect_url = "http://localhost:3000/api/auth/github/callback"

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub latest_articles_count: usize,
     #[serde(default)]
     pub enable_nested_categories: bool,
+    #[serde(default)]
+    pub enable_comments: bool,
     pub github_redirect_url: String,
     #[serde(default = "default_search_index_dir")]
     pub search_index_dir: String,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2,6 +2,7 @@ pub mod article_versions;
 pub mod articles;
 pub mod auth;
 pub mod categories;
+pub mod comments;
 pub mod error;
 pub mod search;
 pub mod sitemap;

--- a/src/handlers/comments.rs
+++ b/src/handlers/comments.rs
@@ -1,0 +1,11 @@
+use crate::server::app::AppState;
+use axum::{Router, routing::get};
+use std::sync::Arc;
+
+pub fn create_router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/comments", get(not_implemented))
+}
+
+async fn not_implemented() -> &'static str {
+    "Comments feature not implemented"
+}

--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -73,14 +73,20 @@ pub fn start_file_watcher(app_state: Arc<AppState>) {
 }
 
 pub async fn start_server(app_state: Arc<AppState>, config: &Config) {
-    let app = Router::new()
+    let mut app = Router::new()
         .merge(crate::handlers::articles::create_router())
         .merge(crate::handlers::article_versions::create_router())
         .merge(crate::handlers::tags::create_router())
         .merge(crate::handlers::categories::create_router())
         .merge(crate::handlers::search::create_router())
         .merge(crate::handlers::auth::create_router())
-        .merge(crate::handlers::sitemap::create_router())
+        .merge(crate::handlers::sitemap::create_router());
+
+    if config.enable_comments {
+        app = app.merge(crate::handlers::comments::create_router());
+    }
+
+    let app = app
         .layer(middleware::from_fn(log_errors))
         .layer(ResponseCacheLayer::new(app_state.cache.clone()))
         .with_state(app_state);


### PR DESCRIPTION
## Summary
- add `enable_comments` flag to configuration and documentation
- conditionally register comment routes when comments are enabled
- stub comments handler

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c07729e7a4832a892581789168867e