### PR TITLE
Preserve response Content-Type in cache

### DIFF
--- a/src/server/app.rs
+++ b/src/server/app.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::server::cache::ResponseCacheLayer;
+use crate::server::cache::{CachedResponse, ResponseCacheLayer};
 use crate::services::search::SearchService;
 use crate::services::service::ArticleStore;
 use axum::body::Body;
@@ -21,7 +21,7 @@ pub struct AppState {
     pub store: Arc<RwLock<ArticleStore>>,
     pub config: Arc<Config>,
     pub search_service: Option<Arc<SearchService>>,
-    pub cache: Arc<Cache<String, String>>,
+    pub cache: Arc<Cache<String, CachedResponse>>,
     pub cookie_key: Key,
 }
 


### PR DESCRIPTION
## Summary
- store cached body with its original Content-Type header
- update app state to use new cached response type

## Testing
- `cargo test --quiet` *(fails: command produced no output and was manually terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c07835f8a0832abd52e5b919589340