### PR TITLE
refactor: improve error handling and config validation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -114,12 +114,10 @@ pub fn initialize_config() -> Result<Arc<Config>, Box<dyn std::error::Error>> {
     config
         .validate()
         .map_err(|e| format!("Configuration validation failed: {}", e))?;
-    env::var("ADMIN_TOKEN_HASH")
-        .map_err(|_| "ADMIN_TOKEN_HASH environment variable must be set")?;
-    env::var("GITHUB_CLIENT_ID")
-        .map_err(|_| "GITHUB_CLIENT_ID environment variable must be set")?;
-    env::var("GITHUB_CLIENT_SECRET")
-        .map_err(|_| "GITHUB_CLIENT_SECRET environment variable must be set")?;
+    // Validate required environment variables using their respective helpers
+    get_admin_token_hash()?;
+    get_github_client_id()?;
+    get_github_client_secret()?;
     Ok(Arc::new(config))
 }
 

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -1,6 +1,6 @@
+use crate::config::{get_github_client_id, get_github_client_secret};
 use crate::handlers::error::{AppError, ERR_INTERNAL_SERVER, ERR_UNAUTHORIZED};
 use crate::server::app::AppState;
-use crate::config::{get_github_client_id, get_github_client_secret};
 use axum::extract::{FromRef, Query, State};
 use axum::response::Redirect;
 use axum::routing::get;
@@ -42,8 +42,7 @@ pub fn create_router() -> Router<Arc<AppState>> {
 
 fn oauth_client(state: &AppState) -> BasicClient {
     let client_id = get_github_client_id().expect("GITHUB_CLIENT_ID must be set");
-    let client_secret =
-        get_github_client_secret().expect("GITHUB_CLIENT_SECRET must be set");
+    let client_secret = get_github_client_secret().expect("GITHUB_CLIENT_SECRET must be set");
     BasicClient::new(
         ClientId::new(client_id),
         Some(ClientSecret::new(client_secret)),

--- a/src/handlers/sitemap.rs
+++ b/src/handlers/sitemap.rs
@@ -1,4 +1,4 @@
-use crate::handlers::error::AppError;
+use crate::handlers::error::{AppError, ERR_INTERNAL_SERVER};
 use crate::server::app::AppState;
 use axum::Router;
 use axum::extract::State;
@@ -30,10 +30,11 @@ async fn get_sitemap(State(state): State<Arc<AppState>>) -> Result<Response, App
 
     xml.push_str("</urlset>");
 
-    let response = Response::builder()
+    Response::builder()
         .header(header::CONTENT_TYPE, "application/xml")
         .body(axum::body::Body::from(xml))
-        .unwrap();
-
-    Ok(response)
+        .map_err(|_| AppError::InternalServerError {
+            code: ERR_INTERNAL_SERVER,
+            message: "Failed to build sitemap response".to_string(),
+        })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     initialize_logging(&config);
     let app_state = create_app_state(&config).await?;
     start_file_watcher(Arc::clone(&app_state));
-    start_server(app_state, &config).await;
+    start_server(app_state, &config).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- validate required environment variables using existing helpers
- return server startup errors instead of panicking
- handle sitemap response builder errors gracefully
- tidy auth handler imports

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c07ad87948832a896c556930d6c872