### PR TITLE
refactor: centralize markdown-it instance

### DIFF
--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -1,0 +1,3 @@
+import MarkdownIt from 'markdown-it'
+
+export const md = new MarkdownIt()

--- a/frontend/src/views/ArticleNewView.vue
+++ b/frontend/src/views/ArticleNewView.vue
@@ -66,9 +66,9 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { ElMessage } from 'element-plus'
-import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
 import { getToken } from '../utils/storage'
+import { md } from '../utils/markdown'
 
 const form = ref({
   title: '',
@@ -85,7 +85,6 @@ const rules = {
 }
 
 const isPreview = ref(false)
-const md = new MarkdownIt()
 const previewHTML = computed(() =>
   DOMPurify.sanitize(md.render(form.value.content || ''))
 )

--- a/frontend/src/views/ArticleVersionView.vue
+++ b/frontend/src/views/ArticleVersionView.vue
@@ -10,16 +10,14 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
-import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
+import { md } from '../utils/markdown'
 
 const route = useRoute()
 const slug = route.params.slug
 const version = route.params.version
 const versionData = ref(null)
 const error = ref('')
-
-const md = new MarkdownIt()
 
 const sanitizedHtml = computed(() => {
   if (!versionData.value) return ''

--- a/frontend/src/views/ArticleView.vue
+++ b/frontend/src/views/ArticleView.vue
@@ -22,17 +22,15 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
-import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
 import { getToken, isAdmin } from '../utils/storage'
+import { md } from '../utils/markdown'
 
 const route = useRoute()
 const article = ref(null)
 const versions = ref([])
 const error = ref('')
 const isAuthorized = isAdmin()
-
-const md = new MarkdownIt()
 
 const sanitizedHtml = computed(() => {
   if (!article.value) return ''

--- a/frontend/src/views/NoteView.vue
+++ b/frontend/src/views/NoteView.vue
@@ -12,14 +12,12 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
-import MarkdownIt from 'markdown-it'
 import DOMPurify from 'dompurify'
+import { md } from '../utils/markdown'
 
 const route = useRoute()
 const note = ref(null)
 const error = ref('')
-
-const md = new MarkdownIt()
 
 const sanitizedHtml = computed(() => {
   if (!note.value) return ''


### PR DESCRIPTION
## Summary
- export a shared `md` instance from `frontend/src/utils/markdown.js`
- update views to import the shared Markdown renderer instead of creating their own

## Testing
- `cd frontend && pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c4e312b55c832a8d65b2ee8aa09f9a