### PR TITLE
feat(frontend): centralize article data and auth in Pinia store

### DIFF
--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,13 +1,51 @@
 import { defineStore } from 'pinia'
+import {
+  getToken as loadToken,
+  setToken as saveToken,
+  clearToken,
+  isAdmin,
+  setIsAdmin
+} from '../utils/storage'
 
-export const useCounterStore = defineStore('counter', {
-  state: () => ({ count: 0 }),
-  getters: {
-    double: state => state.count * 2,
-  },
+export const useMainStore = defineStore('main', {
+  state: () => ({
+    articles: [],
+    currentArticle: null,
+    user: { isAdmin: isAdmin() },
+    token: loadToken() || ''
+  }),
   actions: {
-    increment() {
-      this.count++
+    async fetchArticles(params = {}) {
+      const query = new URLSearchParams(params).toString()
+      const res = await fetch(`/api/articles${query ? `?${query}` : ''}`)
+      if (res.ok) {
+        const data = await res.json()
+        this.articles = data.articles || []
+      } else {
+        this.articles = []
+        throw new Error('Request failed')
+      }
     },
-  },
+    async fetchArticle(slug) {
+      const res = await fetch(`/api/articles/${slug}`)
+      if (res.ok) {
+        this.currentArticle = await res.json()
+      } else {
+        this.currentArticle = null
+        throw new Error('Request failed')
+      }
+    },
+    setUser(user) {
+      this.user = user
+      setIsAdmin(user?.isAdmin)
+    },
+    setToken(token) {
+      this.token = token
+      if (token) {
+        saveToken(token)
+      } else {
+        clearToken()
+      }
+    }
+  }
 })

--- a/frontend/src/views/ArticleNewView.vue
+++ b/frontend/src/views/ArticleNewView.vue
@@ -67,8 +67,10 @@
 import { ref, onMounted, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import DOMPurify from 'dompurify'
-import { getToken } from '../utils/storage'
 import { md } from '../utils/markdown'
+import { useMainStore } from '../store'
+
+const store = useMainStore()
 
 const form = ref({
   title: '',
@@ -131,7 +133,7 @@ async function submit() {
     return
   }
   try {
-    const token = getToken()
+    const token = store.token
     const res = await fetch('/api/articles', {
       method: 'POST',
       headers: {

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="home">
-    <ul v-if="articles.length">
-      <li v-for="a in articles" :key="a.slug">
+    <ul v-if="store.articles.length">
+      <li v-for="a in store.articles" :key="a.slug">
         <router-link :to="`/articles/${a.slug}`">{{ a.metadata.title }}</router-link>
       </li>
     </ul>
@@ -13,25 +13,21 @@
 <script setup>
 import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useMainStore } from '../store'
 
-const articles = ref([])
+const store = useMainStore()
 const error = ref('')
 const route = useRoute()
 
 const fetchArticles = async () => {
   try {
-    const params = new URLSearchParams()
-    if (route.query.tag) params.set('tag', route.query.tag)
-    if (route.query.category) params.set('category', route.query.category)
-    const query = params.toString()
-    const res = await fetch(`/api/articles${query ? `?${query}` : ''}`)
-    if (!res.ok) throw new Error('Request failed')
-    const data = await res.json()
-    articles.value = data.articles || []
+    const params = {}
+    if (route.query.tag) params.tag = route.query.tag
+    if (route.query.category) params.category = route.query.category
+    await store.fetchArticles(params)
     error.value = ''
   } catch (e) {
     error.value = 'Failed to load'
-    articles.value = []
   }
 }
 


### PR DESCRIPTION
## Summary
- add Pinia store for articles, current article, user info and token
- home and article views read data from store instead of local state
- new article view submits using token from store

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c4e5c0e938832ab4700cf82f666632