### PR TITLE
feat(frontend): add friendly loading and error states

### DIFF
--- a/frontend/src/components/StateWrapper.vue
+++ b/frontend/src/components/StateWrapper.vue
@@ -1,0 +1,22 @@
+<template>
+  <el-skeleton v-if="loading" animated />
+  <el-empty v-else-if="error" :description="error" />
+  <el-empty v-else-if="!hasContent" />
+  <slot v-else />
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+// eslint-disable-next-line no-undef
+const props = defineProps({
+  loading: Boolean,
+  error: String,
+  data: { type: [Array, Object], default: null }
+})
+
+const hasContent = computed(() => {
+  if (Array.isArray(props.data)) return props.data.length > 0
+  return !!props.data
+})
+</script>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="home">
-    <ul v-if="store.articles.length">
-      <li v-for="a in store.articles" :key="a.slug">
-        <router-link :to="`/articles/${a.slug}`">{{ a.metadata.title }}</router-link>
-      </li>
-    </ul>
-    <p v-else-if="error">{{ error }}</p>
-    <p v-else>Loading...</p>
+    <StateWrapper :loading="loading" :error="error" :data="store.articles">
+      <ul>
+        <li v-for="a in store.articles" :key="a.slug">
+          <router-link :to="`/articles/${a.slug}`">{{ a.metadata.title }}</router-link>
+        </li>
+      </ul>
+    </StateWrapper>
   </div>
 </template>
 
@@ -14,12 +14,15 @@
 import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useMainStore } from '../store'
+import StateWrapper from '../components/StateWrapper.vue'
 
 const store = useMainStore()
 const error = ref('')
+const loading = ref(false)
 const route = useRoute()
 
 const fetchArticles = async () => {
+  loading.value = true
   try {
     const params = {}
     if (route.query.tag) params.tag = route.query.tag
@@ -28,6 +31,8 @@ const fetchArticles = async () => {
     error.value = ''
   } catch (e) {
     error.value = 'Failed to load'
+  } finally {
+    loading.value = false
   }
 }
 

--- a/frontend/src/views/NotesView.vue
+++ b/frontend/src/views/NotesView.vue
@@ -1,24 +1,27 @@
 <template>
   <div class="notes">
-    <ul v-if="notes.length">
-      <li v-for="n in notes" :key="n.slug">
-        <router-link :to="`/notes/${n.slug}`">{{ n.metadata.title }}</router-link>
-      </li>
-    </ul>
-    <p v-else-if="error">{{ error }}</p>
-    <p v-else>Loading...</p>
+    <StateWrapper :loading="loading" :error="error" :data="notes">
+      <ul>
+        <li v-for="n in notes" :key="n.slug">
+          <router-link :to="`/notes/${n.slug}`">{{ n.metadata.title }}</router-link>
+        </li>
+      </ul>
+    </StateWrapper>
   </div>
 </template>
 
 <script setup>
 import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import StateWrapper from '../components/StateWrapper.vue'
 
 const notes = ref([])
 const error = ref('')
+const loading = ref(false)
 const route = useRoute()
 
 const fetchNotes = async () => {
+  loading.value = true
   try {
     const params = new URLSearchParams()
     if (route.query.tag) params.set('tag', route.query.tag)
@@ -32,6 +35,8 @@ const fetchNotes = async () => {
   } catch (e) {
     error.value = 'Failed to load'
     notes.value = []
+  } finally {
+    loading.value = false
   }
 }
 


### PR DESCRIPTION
## Summary
- add StateWrapper component with Element Plus skeleton/empty
- show friendly loading and error states on home and notes views

## Testing
- `cd frontend && pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c4e8360ea0832a81908412d59067b7