### PR TITLE
fix(frontend): default to initial value when response JSON is falsy

### DIFF
--- a/frontend/src/composables/useApi.js
+++ b/frontend/src/composables/useApi.js
@@ -20,7 +20,7 @@ export default function useApi(initialValue = null) {
         }
         throw new Error(message)
       }
-      data.value = await res.json()
+      data.value = (await res.json()) || initialValue
     } catch (e) {
       error.value = e.message || 'Failed to load'
     } finally {


### PR DESCRIPTION
## Summary
- fallback to initial value in useApi composable if response JSON is falsy

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4e8ff7990832aa864b1b9a0245f9c