### PR TITLE
feat(frontend): add retry with exponential backoff

### DIFF
--- a/frontend/src/composables/useApi.js
+++ b/frontend/src/composables/useApi.js
@@ -1,31 +1,48 @@
 import { ref } from 'vue'
 
-export default function useApi(initialValue = null) {
+export default function useApi(initialValue = null, { retries = 3, retryDelay = 500 } = {}) {
   const data = ref(initialValue)
   const error = ref('')
   const loading = ref(false)
 
-  const request = async (url, options) => {
+  const request = async (url, options, config = {}) => {
     loading.value = true
     error.value = ''
-    try {
-      const res = await fetch(url, options)
-      if (!res.ok) {
-        let message = 'Request failed'
-        try {
-          const errData = await res.json()
-          message = errData.message || message
-        } catch (_) {
-          // ignore parse error
+
+    const maxRetries = config.retries ?? retries
+    const baseDelay = config.retryDelay ?? retryDelay
+    let attempt = 0
+    let delay = baseDelay
+    let lastError
+
+    while (attempt < maxRetries) {
+      try {
+        const res = await fetch(url, options)
+        if (!res.ok) {
+          let message = 'Request failed'
+          try {
+            const errData = await res.json()
+            message = errData.message || message
+          } catch (_) {
+            // ignore parse error
+          }
+          throw new Error(message)
         }
-        throw new Error(message)
+        data.value = (await res.json()) || initialValue
+        loading.value = false
+        return
+      } catch (e) {
+        lastError = e
+        attempt++
+        if (attempt < maxRetries) {
+          await new Promise(resolve => setTimeout(resolve, delay))
+          delay *= 2
+        }
       }
-      data.value = (await res.json()) || initialValue
-    } catch (e) {
-      error.value = e.message || 'Failed to load'
-    } finally {
-      loading.value = false
     }
+
+    error.value = lastError?.message || 'Failed to load'
+    loading.value = false
   }
 
   return { data, error, loading, request }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import useApi from '../composables/useApi'
 import {
   getToken as loadToken,
   setToken as saveToken,
@@ -17,22 +18,23 @@ export const useMainStore = defineStore('main', {
   actions: {
     async fetchArticles(params = {}) {
       const query = new URLSearchParams(params).toString()
-      const res = await fetch(`/api/articles${query ? `?${query}` : ''}`)
-      if (res.ok) {
-        const data = await res.json()
-        this.articles = data.articles || []
+      const api = useApi({ articles: [] })
+      await api.request(`/api/articles${query ? `?${query}` : ''}`)
+      if (!api.error.value) {
+        this.articles = api.data.value.articles || []
       } else {
         this.articles = []
-        throw new Error('Request failed')
+        throw new Error(api.error.value)
       }
     },
     async fetchArticle(slug) {
-      const res = await fetch(`/api/articles/${slug}`)
-      if (res.ok) {
-        this.currentArticle = await res.json()
+      const api = useApi()
+      await api.request(`/api/articles/${slug}`)
+      if (!api.error.value) {
+        this.currentArticle = api.data.value
       } else {
         this.currentArticle = null
-        throw new Error('Request failed')
+        throw new Error(api.error.value)
       }
     },
     setUser(user) {


### PR DESCRIPTION
## Summary
- add configurable retry logic with exponential backoff to `useApi`
- refactor Pinia store actions to use `useApi().request`

## Testing
- `cd frontend && pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c4f3691994832a92821444e66d5492