### PR TITLE
feat: debounce article fetching on query change

### DIFF
--- a/frontend/src/utils/debounce.js
+++ b/frontend/src/utils/debounce.js
@@ -1,0 +1,7 @@
+export default function debounce(fn, delay) {
+  let timeout
+  return function (...args) {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => fn.apply(this, args), delay)
+  }
+}

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -15,6 +15,7 @@ import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useMainStore } from '../store'
 import StateWrapper from '../components/StateWrapper.vue'
+import debounce from '../utils/debounce'
 
 const store = useMainStore()
 const error = ref('')
@@ -35,8 +36,9 @@ const fetchArticles = async () => {
     loading.value = false
   }
 }
+const debouncedFetchArticles = debounce(fetchArticles, 300)
 
-watch(() => route.query, fetchArticles, { immediate: true })
+watch(() => route.query, debouncedFetchArticles, { immediate: true })
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add simple debounce utility
- throttle HomeView article fetching with 300ms debounce

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4f4c58b04832a93eb19967e0d120b