### PR TITLE
Validate user profile input on update

### DIFF
--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -1,8 +1,13 @@
-use crate::handlers::error::{AppError, ERR_INTERNAL_SERVER};
+use crate::handlers::error::{AppError, ERR_BAD_REQUEST, ERR_INTERNAL_SERVER};
 use crate::models::user::User;
 use crate::models::user_preferences::UserPreferences;
+use crate::server::app::AppState;
+use axum::extract::State;
+use axum::routing::put;
+use axum::{Json, Router};
 use reqwest::header::USER_AGENT;
 use serde::Deserialize;
+use std::sync::Arc;
 
 /// Representation of the subset of GitHub's user profile fields we care about
 #[derive(Debug, Deserialize)]
@@ -64,4 +69,100 @@ pub fn apply_github_profile(
     } else if let Some(p) = prefs {
         user.avatar = p.avatar.clone();
     }
+}
+
+#[derive(Deserialize)]
+pub struct UpdateProfileRequest {
+    pub display_name: Option<String>,
+    pub bio: Option<String>,
+    pub website: Option<String>,
+    pub theme: Option<String>,
+    pub language: Option<String>,
+}
+
+const ALLOWED_THEMES: &[&str] = &["light", "dark"];
+const ALLOWED_LANGUAGES: &[&str] = &["en", "zh"];
+
+fn validate_profile(input: &UpdateProfileRequest) -> Result<(), AppError> {
+    if let Some(name) = &input.display_name {
+        if name.len() > 50 {
+            return Err(AppError::BadRequest {
+                code: ERR_BAD_REQUEST,
+                message: "display_name too long".to_string(),
+            });
+        }
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == ' ' || c == '-' || c == '_')
+        {
+            return Err(AppError::BadRequest {
+                code: ERR_BAD_REQUEST,
+                message: "display_name contains invalid characters".to_string(),
+            });
+        }
+    }
+
+    if let Some(bio) = &input.bio {
+        if bio.len() > 160 {
+            return Err(AppError::BadRequest {
+                code: ERR_BAD_REQUEST,
+                message: "bio too long".to_string(),
+            });
+        }
+    }
+
+    if let Some(website) = &input.website {
+        if website.len() > 200 {
+            return Err(AppError::BadRequest {
+                code: ERR_BAD_REQUEST,
+                message: "website too long".to_string(),
+            });
+        }
+        if reqwest::Url::parse(website).is_err() {
+            return Err(AppError::BadRequest {
+                code: ERR_BAD_REQUEST,
+                message: "invalid website".to_string(),
+            });
+        }
+    }
+
+    if let Some(theme) = &input.theme {
+        if !ALLOWED_THEMES.contains(&theme.as_str()) {
+            return Err(AppError::BadRequest {
+                code: ERR_BAD_REQUEST,
+                message: "invalid theme".to_string(),
+            });
+        }
+    }
+
+    if let Some(language) = &input.language {
+        if !ALLOWED_LANGUAGES.contains(&language.as_str()) {
+            return Err(AppError::BadRequest {
+                code: ERR_BAD_REQUEST,
+                message: "invalid language".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+async fn update_profile(
+    State(_state): State<Arc<AppState>>,
+    Json(payload): Json<UpdateProfileRequest>,
+) -> Result<Json<UserPreferences>, AppError> {
+    validate_profile(&payload)?;
+    let prefs = UserPreferences {
+        display_name: payload.display_name,
+        bio: payload.bio,
+        avatar: None,
+        website: payload.website,
+        theme: payload.theme,
+        language: payload.language,
+    };
+    Ok(Json(prefs))
+}
+
+pub fn create_router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/users/me/profile", put(update_profile))
 }

--- a/backend/src/models/user_preferences.rs
+++ b/backend/src/models/user_preferences.rs
@@ -9,4 +9,7 @@ pub struct UserPreferences {
     pub display_name: Option<String>,
     pub bio: Option<String>,
     pub avatar: Option<String>,
+    pub website: Option<String>,
+    pub theme: Option<String>,
+    pub language: Option<String>,
 }

--- a/backend/src/server/app.rs
+++ b/backend/src/server/app.rs
@@ -131,7 +131,8 @@ pub async fn start_server(
         .merge(crate::handlers::tags::create_router())
         .merge(crate::handlers::categories::create_router())
         .merge(crate::handlers::search::create_router())
-        .merge(crate::handlers::sitemap::create_router());
+        .merge(crate::handlers::sitemap::create_router())
+        .merge(crate::handlers::users::create_router());
 
     if config.comments {
         app = app


### PR DESCRIPTION
## Summary
- add server-side validation for PUT /api/users/me/profile
- extend user preferences with website, theme, and language
- register users router with profile update endpoint

## Testing
- `cargo test` *(fails: handlers::articles::tests::test_persist_article - No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5243533e4832aa49b58b9b6c9aaa1