### PR TITLE
Set path for user session cookie

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -134,6 +134,7 @@ async fn github_callback(
             .http_only(true)
             .same_site(SameSite::Lax)
             .secure(is_secure_cookie)
+            .path("/")
             .max_age(cookie::time::Duration::days(30))
             .build(),
     );
@@ -147,10 +148,11 @@ async fn get_current_user(jar: SignedJar) -> Result<Json<UserInfo>, AppError> {
         message: "Not authenticated".to_string(),
     })?;
 
-    let user: User = serde_json::from_str(user_cookie.value()).map_err(|_| AppError::Unauthorized {
-        code: ERR_UNAUTHORIZED,
-        message: "Invalid session".to_string(),
-    })?;
+    let user: User =
+        serde_json::from_str(user_cookie.value()).map_err(|_| AppError::Unauthorized {
+            code: ERR_UNAUTHORIZED,
+            message: "Invalid session".to_string(),
+        })?;
 
     Ok(Json(UserInfo::from(user)))
 }


### PR DESCRIPTION
## Summary
- ensure GitHub login sets `user_session` cookie for the site root

## Testing
- `cargo test`
- `curl -i -H 'Cookie: user_session=9gJK6vE8gR6+qa0h+bN7z3haEc/3qDkk/c/b+jYq2HM={"github_id":1,"github_login":"test","role":"Visitor","display_name":"test","bio":null,"avatar":null}' http://127.0.0.1:3000/api/auth/me`


------
https://chatgpt.com/codex/tasks/task_e_68c531f791d8832ab749426f4a6a67d4